### PR TITLE
Convert repo-local issue references to absolute ones in commit messages

### DIFF
--- a/exe/merge_rspec_repos
+++ b/exe/merge_rspec_repos
@@ -3,6 +3,7 @@
 
 require 'bundler/setup'
 require_relative '../lib/repository_merger'
+require_relative '../lib/repository_merger/github_issue_reference'
 require 'pry'
 
 def main
@@ -30,7 +31,14 @@ def main
     target_branch_names,
     commit_message_transformer: proc do |original_commit|
       scope = original_commit.repo.name.sub(/\Arspec-/, '')
-      "[#{scope}] #{original_commit.message}"
+
+      message = RepositoryMerger::GitHubIssueReference.convert_repo_local_references_to_absolute_ones_in(
+        original_commit.message,
+        username: 'rspec',
+        repo_name: original_commit.repo.name
+      )
+
+      "[#{scope}] #{message}"
     end
   )
 

--- a/lib/repository_merger/github_issue_reference.rb
+++ b/lib/repository_merger/github_issue_reference.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class RepositoryMerger
+  module GitHubIssueReference
+    RepositoryLocalReference = Struct.new(:issue_number, keyword_init: true)
+    AbsoluteReference = Struct.new(:username, :repo_name, :issue_number, keyword_init: true)
+
+    # https://github.com/isiahmeadows/github-limits
+    USERNAME_PATTERN = /(?<username>[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})/i
+    REPOSITORY_NAME_PATTERN = /(?<repo_name>[a-z0-9\.\-_]{1,100})/i
+    ISSUE_NUMBER_PATTERN = /(?<issue_number>\d{1,5})/ # Technically max is 1073741824 but it won't exist in real life
+
+    # https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests
+    REPO_LOCAL_REFERENCE_PATTERN = /(?<!\w)(?<repo_local_reference>(?:#|GH-)#{ISSUE_NUMBER_PATTERN})(?!\w)/i
+    ABSOLUTE_REFERENCE_PATTERN = /(?<!\w)(?<absolute_reference>#{USERNAME_PATTERN}\/#{REPOSITORY_NAME_PATTERN}##{ISSUE_NUMBER_PATTERN})(?!\w)/
+    REFERENCE_PATTERN = /(?:#{REPO_LOCAL_REFERENCE_PATTERN}|#{ABSOLUTE_REFERENCE_PATTERN})/
+
+    def self.extract_references_from(message)
+      references = []
+
+      message.scan(REFERENCE_PATTERN) do
+        reference = create_referece_from(Regexp.last_match)
+        references << reference if reference
+      end
+
+      references
+    end
+
+    def self.convert_repo_local_references_to_absolute_ones_in(message, username:, repo_name:)
+      message.gsub(REPO_LOCAL_REFERENCE_PATTERN) do
+        reference = create_referece_from(Regexp.last_match)
+        raise unless reference
+        "#{username}/#{repo_name}##{reference.issue_number}"
+      end
+    end
+
+    def self.create_referece_from(match)
+      if match[:repo_local_reference]
+        RepositoryLocalReference.new(issue_number: Integer(match[:issue_number]))
+      elsif match[:absolute_reference]
+        AbsoluteReference.new(
+          username: match[:username],
+          repo_name: match[:repo_name],
+          issue_number: Integer(match[:issue_number])
+        )
+      end
+    end
+  end
+end

--- a/spec/repository_merger/github_issue_reference_spec.rb
+++ b/spec/repository_merger/github_issue_reference_spec.rb
@@ -1,0 +1,228 @@
+require 'repository_merger/github_issue_reference'
+require 'json'
+
+class RepositoryMerger
+  RSpec.describe GitHubIssueReference do
+    def a_repo_local_reference(issue_number:)
+      an_instance_of(GitHubIssueReference::RepositoryLocalReference)
+        .and an_object_having_attributes(issue_number: issue_number)
+    end
+
+    def an_absolute_reference(username:, repo_name:, issue_number:)
+      an_instance_of(GitHubIssueReference::AbsoluteReference)
+        .and an_object_having_attributes(
+          username: username,
+          repo_name: repo_name,
+          issue_number: issue_number
+        )
+    end
+
+    describe '.convert_repo_local_references_to_absolute_references_in' do
+      subject(:converted_message) do
+        GitHubIssueReference.convert_repo_local_references_to_absolute_ones_in(
+          original_message,
+          username: 'rspec',
+          repo_name: 'rspec-core'
+        )
+      end
+
+      let(:original_message) { <<~END}
+        Merge pull request #372 from danielgrippi/patch-1
+
+        Fixes rspec/rspec-mocks#123 and #456.
+      END
+
+      it 'converts only repo-local references' do
+        expect(converted_message).to eq(<<~END)
+          Merge pull request rspec/rspec-core#372 from danielgrippi/patch-1
+
+          Fixes rspec/rspec-mocks#123 and rspec/rspec-core#456.
+        END
+      end
+    end
+
+    describe '.extract_references_from' do
+      subject(:extracted_references) do
+        GitHubIssueReference.extract_references_from(message)
+      end
+
+      context 'with a repo-local reference in auto-generated message for merged pull request' do
+        let(:message) { <<~END}
+          Merge pull request #372 from danielgrippi/patch-1
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 372)
+          ])
+        end
+      end
+
+      context 'with only #123' do
+        let(:message) { <<~END}
+          #123
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with #123 in the body' do
+        let(:message) { <<~END}
+          Subject
+
+          #123
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with [#123]' do
+        let(:message) { <<~END}
+          [#123]
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with (#123)' do
+        let(:message) { <<~END}
+          [#123]
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with foo-#123' do
+        let(:message) { <<~END}
+          foo-#123
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with #123-foo' do
+        let(:message) { <<~END}
+          #123-foo
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with _#123' do
+        let(:message) { <<~END}
+          _#123
+        END
+
+        it 'extracts nothing' do
+          expect(extracted_references).to be_empty
+        end
+      end
+
+      context 'with #123_' do
+        let(:message) { <<~END}
+          #123_
+        END
+
+        it 'extracts nothing' do
+          expect(extracted_references).to be_empty
+        end
+      end
+
+      context 'with foo#123' do
+        let(:message) { <<~END}
+          foo#123
+        END
+
+        it 'extracts nothing' do
+          expect(extracted_references).to be_empty
+        end
+      end
+
+      context 'with rspec/rspec-core#123' do
+        let(:message) { <<~END}
+          Fix error with using custom matchers inside other custom matcher rspec/rspec-core#592
+        END
+
+        it 'extracts the reference' do
+          expect(extracted_references).to match([
+            an_absolute_reference(username: 'rspec', repo_name: 'rspec-core', issue_number: 592)
+          ])
+        end
+      end
+
+      context 'with multiple references' do
+        let(:message) { <<~END}
+          #123 rspec/rspec-core#456 #789
+        END
+
+        it 'extracts the references' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123),
+            an_absolute_reference(username: 'rspec', repo_name: 'rspec-core', issue_number: 456),
+            a_repo_local_reference(issue_number: 789)
+          ])
+        end
+      end
+
+      context 'with GH-123' do
+        let(:message) { <<~END}
+          GH-123
+        END
+
+        it 'extracts the references' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with gh-123' do
+        let(:message) { <<~END}
+          gh-123
+        END
+
+        it 'extracts the references' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+
+      context 'with gh-123-1' do
+        let(:message) { <<~END}
+          gh-123-1
+        END
+
+        it 'extracts the references' do
+          expect(extracted_references).to match([
+            a_repo_local_reference(issue_number: 123)
+          ])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For example, commits in rspec-core repo that have message like:

```
Merge pull request #372 from someone/patch-1
```

... would be imported into monorepo with message:

```
Merge pull request rspec/rspec-core#372 from someone/patch-1
```